### PR TITLE
Overhaul the UART_IRQ module.

### DIFF
--- a/WTC_Flight/Src/gpio.c
+++ b/WTC_Flight/Src/gpio.c
@@ -87,7 +87,7 @@ void MX_GPIO_Init(void)
 
   /*Configure GPIO pin Output Level */
   HAL_GPIO_WritePin(GPIOD, WTC_V_Stack_Pin|Pwr_En_Pi1_Pin|Pwr_En_Pi2_Pin|WTC_BUS_Switch_Pi_Select_Pin 
-                          |Pi_Heartbeat_Pi2_Pin|Pi_Heartbeat_Pi2D15_Pin|_70cm_Primary_TR_Pin|EN_MPPT_Z__Pin 
+                          |Pi_Heartbeat_Pi2_Pin|Pi_Heartbeat_Pi1_Pin|_70cm_Primary_TR_Pin|EN_MPPT_Z__Pin 
                           |EN_MPPT_YZ__Pin|EN_MPPT_YCtr_Pin, GPIO_PIN_RESET);
 
   /*Configure GPIO pin Output Level */
@@ -124,7 +124,7 @@ void MX_GPIO_Init(void)
                            PDPin PDPin PDPin PDPin 
                            PDPin PDPin */
   GPIO_InitStruct.Pin = WTC_V_Stack_Pin|Pwr_En_Pi1_Pin|Pwr_En_Pi2_Pin|WTC_BUS_Switch_Pi_Select_Pin 
-                          |Pi_Heartbeat_Pi2_Pin|Pi_Heartbeat_Pi2D15_Pin|_70cm_Primary_TR_Pin|EN_MPPT_Z__Pin 
+                          |Pi_Heartbeat_Pi2_Pin|Pi_Heartbeat_Pi1_Pin|_70cm_Primary_TR_Pin|EN_MPPT_Z__Pin 
                           |EN_MPPT_YZ__Pin|EN_MPPT_YCtr_Pin;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;

--- a/WTC_Libs/UART_IRQ/UART_IRQ.c
+++ b/WTC_Libs/UART_IRQ/UART_IRQ.c
@@ -3,36 +3,13 @@
 // QPACE
 
 /**
- * @brief  best way to initialize a char array
- * @param  size
- * return char*
- */
-
-char* mallocCharArray(uint32_t size) {
-	char* str = malloc(sizeof(char) * (size + 1));
-	for (int i = 0; i <= size; i++)
-		str[i] = '\0';
-
-	return str;
-}
-
-uint32_t arraylength(char* array) {
-	if (array == 0)
-		return 0;
-
-	uint32_t i = 0;
-	while (array[i] != 0)
-		i++;
-
-	return i;
-}
-/**
  * @brief  best way to insert char to a string
  * @param  dest where string will be copied to
  * @param 	src the string to append to the dest string at index 'index'
  * @param	index start location of appending.
  * return  result of the concatenated strings.
  */
+/*
 char* appendCharArrays(char* dest, char* src, uint32_t index) {
 	uint8_t destLen = 0;
 	uint8_t srcLen = 0;
@@ -73,6 +50,8 @@ char* appendCharArrays(char* dest, char* src, uint32_t index) {
 
 	return result;
 }
+*/
+
 
 /**
  * @brief  This function is executed when waiting for a UART Interrupt
@@ -135,40 +114,22 @@ void UART_PUT(UART_HandleTypeDef *huart, char *str) {
 	HAL_UART_Transmit(huart, (uint8_t *) str, (uint16_t) sizeof(str), 0xFFFF);
 }
 
-void getS(UART_HandleTypeDef *huart, char *buf, uint8_t len) {
-	//HAL_UART_Receive(&huart3, (uint8_t *) buf, len, 0xFFFF);
-	//buf[strlen(buf)] = '\0';
-	HAL_UART_Receive(huart, (uint8_t *) buf, len + 1, 0xFFFF);
-	buf[strlen((buf)) - 1] = '\0';
+void getS(UART_HandleTypeDef *huart, char *buf, uint16_t max_len) {
+	for(uint16_t i = 0; i < max_len; i++) {
+		HAL_UART_Receive(huart, (uint8_t*)(buf + i), 1, 0xFFFF);
+		if(buf[i] == '\0')
+			break;
+	}
 }
 
 void putS(UART_HandleTypeDef *huart, char* buf) {
-
-	uint8_t size = 0;
-
-	while (buf[size] != 0)
-		size++;
-
-	//
-	// sizeof DOESNT NOT WORK!!!!!!!!!
-	// HAL_UART_Transmit(&huart3, (uint8_t *) buf, (uint16_t) sizeof(buf), 0xFFFF);
-	HAL_UART_Transmit(huart, (uint8_t *) buf, (uint16_t) size, 1000/*0xFFFF*/);
-
+	HAL_UART_Transmit(huart, (uint8_t *)buf, strlen(buf), 0xFFFF);
 }
 
-/*
- * 	puts for binary
- *	used when not trusting the '\0' character for ending the buffer
- *
- *	len - total bytes
- */
 void putB(UART_HandleTypeDef *huart, char* buf, uint16_t len) {
-
 	HAL_UART_Transmit(huart, (uint8_t *) buf, len, 0xFFFF);
 }
 
-void getB(UART_HandleTypeDef *huart, char *buf, uint8_t len) {
-	//HAL_UART_Receive(&huart3, (uint8_t *) buf, len, 0xFFFF);
-	//buf[strlen(buf)] = '\0';
-	HAL_UART_Receive(huart, (uint8_t *) buf, len, 1000);
+void getB(UART_HandleTypeDef *huart, char *buf, uint16_t len) {
+	HAL_UART_Receive(huart, (uint8_t *)buf, len, 0xFFFF);
 }

--- a/WTC_Libs/UART_IRQ/UART_IRQ.h
+++ b/WTC_Libs/UART_IRQ/UART_IRQ.h
@@ -13,12 +13,8 @@ void UART_printSOS(UART_HandleTypeDef *huart, uint32_t time);
 void UART_PUT(UART_HandleTypeDef *huart, char *str);
 
 void putS(UART_HandleTypeDef *huart, char* buf);
-void getS(UART_HandleTypeDef *huart, char* buf, uint8_t len);
+void getS(UART_HandleTypeDef *huart, char *buf, uint16_t max_len);
 void putB(UART_HandleTypeDef *huart, char* buf, uint16_t len);
-void getB(UART_HandleTypeDef *huart, char *buf, uint8_t len);
-// char array stuff, useful as supplementary functiosn for
-// the uart functions above ^^^
-char* mallocCharArray(uint32_t size);
-char* appendCharArrays(char* dest, char* src, uint32_t index);
-uint32_t arraylength(char* array);
+void getB(UART_HandleTypeDef *huart, char *buf, uint16_t len);
+
 #endif


### PR DESCRIPTION
Some simplifications to make the code more readable and prone to fewer bugs. Since these functions are simple wrappers of the HAL UART functions, I played around with making them inline, however there were a few other considerations and I didn't really want to play with it too much for fear of introducing some unintended side effects.

They should all be functionally identical to their previous version except for a small change to `getS`: it now accepts a `max_size` argument and reads from UART a character at a time until it encounters a null-byte or hits `max_size`, then terminates and returns the string. Previously, it would accept a `size` argument and the function would block until the UART received `size`-many characters or the timeout was reached. It would then trim the string down to wherever the first null-byte in the buffer was located (minus 1, which appears to have been a bug).

This should not change execution for small strings where the number of characters to read is known, but when reading longer, variable-length strings, this offers a way to halt execution upon receiving a null-byte instead of waiting out the timeout or filling up the buffer.

If this behavior is undesired, it can be reverted without much effort.